### PR TITLE
Update README to mention sandbox project

### DIFF
--- a/flutter_delivery_app/README.md
+++ b/flutter_delivery_app/README.md
@@ -1,3 +1,7 @@
+# This is a sandbox project to try out Copilot workspace
+
 # flutter_delivery_app
 
 A new Flutter project.
+
+This project is for testing purposes only.


### PR DESCRIPTION
Add information about the project being a sandbox for trying out Copilot workspace.

* Add a line at the top of `flutter_delivery_app/README.md` stating that this is a sandbox project to try out Copilot workspace.
* Add a line at the bottom of `flutter_delivery_app/README.md` stating that this project is for testing purposes only.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Sam-alraheb/Copilot-workspace-tryout/pull/3?shareId=6650cd5a-d05c-4695-a901-9311f1abe1d1).